### PR TITLE
downgrade importlib-metadata to less than 5.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pytest = "*"
 flower = "*"
 celery = {extras = ["redis"],version = "*"}
 django-environ = "*"
+importlib-metadata = "<5.0.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "462985408c77aa187b54fb7cd35a81d877f9197d6d79dc9b0722e486b50fc316"
+            "sha256": "49d9dea556daab9fc3ad240e95691a9aa44c79925aba3a60e0ea9956b546bf70"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,7 +71,7 @@
                 "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
                 "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
+            "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
             "version": "==0.3.0"
         },
         "click-plugins": {
@@ -122,11 +122,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
-                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
+                "sha256:8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116",
+                "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"
             ],
-            "markers": "python_version < '3.8'",
-            "version": "==5.0.0"
+            "index": "pypi",
+            "version": "==4.13.0"
         },
         "kombu": {
             "hashes": [
@@ -328,11 +328,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
-                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
+                "sha256:8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116",
+                "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"
             ],
-            "markers": "python_version < '3.8'",
-            "version": "==5.0.0"
+            "index": "pypi",
+            "version": "==4.13.0"
         },
         "iniconfig": {
             "hashes": [


### PR DESCRIPTION
Most recent deploy of flower runner shows the below error:

<img width="1244" alt="Screenshot 2022-11-16 at 10 14 14" src="https://user-images.githubusercontent.com/46938749/202153260-38993bff-f64f-4f4e-9356-63f0ce48093f.png">

As per recommendations in [this answer](https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean) I propose downgrading the version for now. More long term solution might be to try to upgrade python version from 3.7